### PR TITLE
OpenMPI is provided by the link flag: -lgomp. Adding -openmp to LD_LI…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,12 @@ ifndef LIBS
   endif #is on hopper.nersc.gov
  else
     LIBS := $(BLAS_LIB)
-    LDFLAGS := -openmp
+    # test if openmpi libraries have been included in BLAS library path
+    ifneq ($(findstring mp,$(BLAS_LIB)),)
+	LDFLAGS :=
+    else
+    	LDFLAGS := -openmp
+    endif	
  endif #BLAS_LIB
 endif #ifndef $LIBS
 

--- a/utilities/findcp/README.md
+++ b/utilities/findcp/README.md
@@ -47,6 +47,22 @@ file can be changed in `surfgen.in`
 This file defiles the irreducible representation matrices of the CNPI group carried by the quasi-diabatic states used to 
 construct Hd.
 
+* findcp.in
+This file controls search parameters. It is most useful for locating saddle
+points that may be difficult to find easily. Contents:
+ &cpsearch
+   niter       = [100] Maximum number of iterations
+   egrad_tol   = [1d-9] Energy gradient convergence tolerance
+   shift       = [1d-5] Value of shift
+   disp_tol    = [1d-5] Step size convergence tolerance
+   un_infile   = [40] Unit number of input file.
+   grad_scale  = [1d0] Scaling of gradient.
+   hess_disp   = [1d-5] Displacement for hessian calculation.
+   maxdisp     = [1d-1] Maximum size of displacement.
+   sadd_search = ['N'] Saddle point search flag. Not implemented - CLM (2015)
+   old_geomfl  = ['old.geom'] Old geometry file.
+   new_geomfl  = ['new.geom'] New geometry file.
+ /
 Method
 ------
 

--- a/utilities/findcp/findcp.f90
+++ b/utilities/findcp/findcp.f90
@@ -78,26 +78,25 @@ subroutine getFreq(natoms,masses,hess,w,cg,anm,pl,mol)
                 print "(2x,'Mode ',i5,5x,'Frequency: ',f12.2)", i, w(i)
                 do j=1, natoms
                         print "(2x,3f15.8)", &
-                        hmw((j-1)*3 + 1,i)/sqrt(masses(j)), &
-                        hmw((j-1)*3 + 2,i)/sqrt(masses(j)), & 
-                        hmw((j-1)*3 + 3,i)/sqrt(masses(j))
+                        hmw((j-1)*3 + 1,i), &
+                        hmw((j-1)*3 + 2,i), & 
+                        hmw((j-1)*3 + 3,i)
                 end do
         end do
   end if
 
   ! print molden output?
   if (mol) then
-          call gen_molden_file(cg, hmw, w, natoms, masses, anm)
+          call gen_molden_file(cg, hmw, w, natoms, anm)
   end if
   return
 end subroutine getFreq
 
 ! gen_molden_file: generate molden frequency file
-subroutine gen_molden_file(cg, evec, eval, natoms, masses,anames)
+subroutine gen_molden_file(cg, evec, eval, natoms, anames)
         implicit none
         integer, intent(in) :: natoms
         character*3,dimension(natoms) :: anames
-        real*8, dimension(natoms), intent(in)   :: masses
         real*8, dimension(3*natoms), intent(in) :: cg
         real*8, dimension(3*natoms,3*natoms), intent(in) :: evec
         real*8, dimension(3*natoms), intent(in) :: eval
@@ -135,9 +134,9 @@ subroutine gen_molden_file(cg, evec, eval, natoms, masses,anames)
         do i=1, 3*natoms
                 write(mu,"(1x,'vibration',i24)") i
                 do j=1,natoms
-                        write(mu,"(3f13.5)") evec((j-1)*3+1,i)/sqrt(masses(j)), &
-                                evec((j-1)*3+2,i)/sqrt(masses(j)), &
-                                evec((j-1)*3+3,i)/sqrt(masses(j))
+                        write(mu,"(3f13.5)") evec((j-1)*3+1,i), &
+                                evec((j-1)*3+2,i), &
+                                evec((j-1)*3+3,i)
                 end do
         end do
         write(mu,"(1x,A)") "--> end of molden input"

--- a/utilities/findcp/findcp.f90
+++ b/utilities/findcp/findcp.f90
@@ -10,6 +10,8 @@
 !-------------------
 ! Feb 2013        Xiaolei Zhu        Created for NH3 and phenol surfaces
 ! Sep 2013        Xiaolei Zhu        Updated to run for general sytems
+! Nov 2013        cthree-40          Updated for use of input file.
+! Nov 2013        cthree-40          Updated for generation of molden.freq file
 !-------------------
 ! opttools contains subroutines used to analyse the geometry, to calculate
 ! numerical hessian matrix, to search for critical points using Newton-Raphson
@@ -19,11 +21,15 @@ module opttools
  contains
 
 !---calculate harmonic frequencies from hessian matrix
-subroutine getFreq(natoms,masses,hess,w)
+subroutine getFreq(natoms,masses,hess,w,cg,anm,pl,mol)
   implicit none
-  integer,intent(in)          :: natoms
+  integer,intent(in)          :: natoms, pl
   double precision,intent(in) :: masses(natoms),hess(3*natoms,3*natoms)
+  double precision,intent(in) :: cg(3*natoms)
+  logical,intent(in)          :: mol
+  character*3, dimension(natoms), intent(in) :: anm
   double precision,intent(out):: w(3*natoms)
+
   double precision,  parameter  :: amu2au=1.822888484514D3,au2cm1=219474.6305d0
   integer  :: i,j
   double precision  :: sqrm,  hmw(3*natoms,3*natoms), tmp(1)
@@ -40,15 +46,23 @@ subroutine getFreq(natoms,masses,hess,w)
     end do
   end do 
   !calculate eigenvalues of hmw
-  call DSYEVD('N','U',3*natoms,hmw,3*natoms,w,tmp,-1,itmp,-1,INFO)
+  call DSYEVD('V','U',3*natoms,hmw,3*natoms,w,tmp,-1,itmp,-1,INFO)
   if(info/=0)print *,"DSYEVD allocation investigation failed.  info=",info
   LWORK = int(tmp(1))
   LIWORK= itmp(1)
   allocate(WORK(LWORK))
   allocate(IWORK(LIWORK))
   
-  call DSYEVD('N','U',3*natoms,hmw,3*natoms,w,WORK,LWORK,IWORK,LIWORK,INFO)
+  ! if print level is greater than 0 we want to print the modes.
+  if (pl == 0) then
+        call DSYEVD('N','U',3*natoms,hmw,3*natoms,w,WORK,LWORK,IWORK,LIWORK,INFO)
+  else
+        call DSYEVD('V','U',3*natoms,hmw,3*natoms,w,WORK,LWORK,IWORK,LIWORK,INFO)
+  endif
   if(info/=0)print *,"DSYEVD failed.  info=",info
+  
+  
+  
   do i=1,3*natoms
     if(w(i)<0)then
       w(i) = -sqrt(-w(i))*au2cm1
@@ -56,8 +70,78 @@ subroutine getFreq(natoms,masses,hess,w)
       w(i) = sqrt(w(i))*au2cm1
     end if
   end do
+  
+  ! print modes
+  if (pl > 0) then
+        print *," Modes:"
+        do i=1,3*natoms
+                print "(2x,'Mode ',i5,5x,'Frequency: ',f12.2)", i, w(i)
+                do j=1, natoms
+                        print "(2x,3f15.8)", &
+                        hmw((j-1)*3 + 1,i)/sqrt(masses(j)), &
+                        hmw((j-1)*3 + 2,i)/sqrt(masses(j)), & 
+                        hmw((j-1)*3 + 3,i)/sqrt(masses(j))
+                end do
+        end do
+  end if
+
+  ! print molden output?
+  if (mol) then
+          call gen_molden_file(cg, hmw, w, natoms, masses, anm)
+  end if
+  return
 end subroutine getFreq
 
+! gen_molden_file: generate molden frequency file
+subroutine gen_molden_file(cg, evec, eval, natoms, masses,anames)
+        implicit none
+        integer, intent(in) :: natoms
+        character*3,dimension(natoms) :: anames
+        real*8, dimension(natoms), intent(in)   :: masses
+        real*8, dimension(3*natoms), intent(in) :: cg
+        real*8, dimension(3*natoms,3*natoms), intent(in) :: evec
+        real*8, dimension(3*natoms), intent(in) :: eval
+        
+        integer :: mu=11
+        character*25 :: mn
+
+        integer :: ios, i, j
+
+        write(mn,"(a)") "molden.freq"
+        mn=trim(mn)
+
+        open(file=mn,unit=mu,action='write',status='unknown',iostat=ios)
+        if (ios .ne. 0) then
+                print "(A)", "Could not open molden file. No file generated."
+                return
+        end if 
+
+        ! print header
+        write(mu,"(1x,A)") "-- > start of molden input"
+        write(mu,"(1x,A)") "[Molden Format]"
+        ! print frequencies
+        write(mu,"(1x,A)") "[FREQ]"
+        do i=1,3*natoms
+                write(mu,"(f10.2)") eval(i)
+        end do
+        ! print geometry
+        write(mu,"(1x,A)") "[FR-COORD]"
+        do i=1, natoms
+                write(mu,"(1x,a3,3f13.6)") trim(anames(i)), &
+                        cg((i-1)*3+1),cg((i-1)*3+2),cg((i-1)*3+3)
+        end do
+        ! print modes
+        write(mu,"(1x,A)") "[FR-NORM-COORD]"
+        do i=1, 3*natoms
+                write(mu,"(1x,'vibration',i24)") i
+                do j=1,natoms
+                        write(mu,"(3f13.5)") evec((j-1)*3+1,i)/sqrt(masses(j)), &
+                                evec((j-1)*3+2,i)/sqrt(masses(j)), &
+                                evec((j-1)*3+3,i)/sqrt(masses(j))
+                end do
+        end do
+        write(mu,"(1x,A)") "--> end of molden input"
+end subroutine gen_molden_file
 
 !---calculate hessian at a certain geometry
 subroutine calcHess(natoms,cgeom,nstate,istate,stepsize,hessian,centerd,skip)
@@ -113,23 +197,41 @@ end subroutine calcHess
 
 
 !----search for minimum on adiabatic surfaces 
-subroutine findmin(natoms,nstate,cgeom,isurf,maxiter,shift,Etol,Stol)
+subroutine findmin(natoms,nstate,cgeom,isurf,maxiter,shift,Etol,Stol,gscale,hess_disp,MAXD, &
+   masses, sadd_srch, converge_test)
   implicit none
   integer, intent(in)                                 ::  natoms,isurf,maxiter,nstate
   double precision,dimension(3*natoms),intent(inout)  ::  cgeom
-  double precision,intent(in)                         ::  shift,Etol,Stol
-
+  integer, intent(inout)                              :: converge_test
+  double precision,intent(in)                         ::  shift,Etol,Stol, gscale, hess_disp
+  double precision, intent(in)                        :: MAXD !Max displacement size
+  character(len=1),intent(in)                         :: sadd_srch
+  
   real*8    ::  h(nstate,nstate),cg(3*natoms,nstate,nstate),dcg(3*natoms,nstate,nstate),e(nstate)
   double precision,dimension(3*natoms)  ::  grad, b1, b2, w
   double precision,dimension(3*natoms,3*natoms)  :: hess,hinv
+  double precision,dimension(natoms)             :: masses
   double precision,dimension(:),allocatable :: WORK
   integer,dimension(:),allocatable :: IWORK
   integer           :: LIWORK, LWORK, itmp(1),INFO  
-  integer  ::  iter  , i
+  integer  ::  iter  , i, eig_start
   double precision            :: nrmG, nrmD, tmp(1)
   double precision, external  :: dnrm2
   double precision,  parameter  :: amu2au=1.822888484514D3,au2cm1=219474.6305d0
-  double precision, parameter   :: MAXD = 1D-1
+  double precision,dimension(:),allocatable  :: rem_modes
+  
+  character*3,dimension(natoms) :: ctmp
+
+  ! Derived type for normal mode removal in eigenvalue decomposition procedure.
+  type mode_removed
+      double precision  :: freq
+      integer           :: removed 
+  end type mode_removed
+  ! use this type for normal mode removal list
+  type(mode_removed),dimension(:),allocatable :: rem_mode
+  
+  ! Set convergence flag
+  converge_test=0
 
   ! initialize work spaces
   call DSYEVD('V','U',3*natoms,hess,3*natoms,w,tmp,-1,itmp,-1,INFO)
@@ -138,6 +240,12 @@ subroutine findmin(natoms,nstate,cgeom,isurf,maxiter,shift,Etol,Stol)
   LIWORK= itmp(1)
   allocate(WORK(LWORK))
   allocate(IWORK(LIWORK))
+  
+  ! Allocate mode matrix
+  ! This array will allow users to see what modes are being removed in the eigenvalue decomposition
+  !   procedure.
+  allocate(rem_modes(3*natoms))
+  allocate(rem_mode(3*natoms))
 
   print "(A,I4,A,I4,A)","Searching for minimum on surface ",isurf," in ",maxiter," iterations."
   print "(A)","  Convergence Tolerances"
@@ -146,23 +254,58 @@ subroutine findmin(natoms,nstate,cgeom,isurf,maxiter,shift,Etol,Stol)
      call EvaluateSurfgen(cgeom,e,cg,h,dcg)
      grad = cg(:,isurf,isurf)
      nrmG=dnrm2(3*natoms,grad,1)
-     call calcHess(natoms,cgeom,nstate,isurf,1D-4,hess,.true.)
+     call calcHess(natoms,cgeom,nstate,isurf,hess_disp,hess,.true.)
+     if(iter.eq.1 .or. iter.eq.maxiter)then
+        call writeHess(hess,3*natoms)
+        call getFreq(natoms,masses,hess,w,cgeom,ctmp,0,.false.)
+        do i=1,3*natoms
+          print "(I5,F12.2)",i,w(i)
+        end do
+        do i=1,nstate
+            print "(2x,A,I2,A,F12.8)", " Energy of state ", i,"= ", e(i)
+        end do
+     end if
      hinv = hess
      ! invert the hessian
+     ! Call DSYEVD
      call DSYEVD('V','U',3*natoms,hess,3*natoms,w,WORK,LWORK,IWORK,LIWORK,INFO)
+     ! hess now contains the orthonormal eigenvectors of hess(old)
+     ! w contains the eigenvalues from lowest to highest
      if(info/=0)print *,"DSYEVD failed.  info=",info
-     ! hess. w. hess^T = hess_old
-     ! so x= hess_old^-1.b = hess. w^-1. hess^T. b
-     ! b1= hess^T.g       =>
+     ! [Old Hessian] = [hess][w][hess]^T
+     ! Thus, 
+     !    x = [Old Hessian]^-1[b] = ([hess]w)^-1[hess]^T[b]
+     !
+     ! [b1]= [hess]^T[g]       =>
+     ! Call DGEMV. perform [hess]^T[grad]=b1
+     ! First, scale gradient
+     grad=grad*gscale
      call DGEMV('T',3*natoms,3*natoms,1d0,hess,3*natoms,grad,1,0d0,b1,1)
      ! b1' = w^-1*b1
-     do i=1,3*natoms
+     ! Check if saddle point search
+     if( sadd_srch .EQ. 'Y' ) then
+       eig_start=2      ! First eigenvalue should be large and negative, so we skip it
+       b1(1)=b1(1)/w(1)
+     else
+       eig_start=1      ! Otherwise, we continue as normal
+     end if
+     !
+     rem_modes=0
+     do i=eig_start,3*natoms
       if(abs(w(i))<shift)then
-         b1(i)=dble(0)
+         b1(i)=b1(i)
+         rem_mode(i)%freq=w(i)
+         rem_mode(i)%removed=1
       else!
          b1(i)=b1(i)/w(i)
       end if!
      end do!
+     ! Print out to what modes are being removed
+     do i=1, 3*natoms
+       if ( rem_mode(i)%removed .eq. 1 ) then      ! If mode was removed, print info
+         write(*,1001) i, rem_mode(i)%freq
+       end if
+     end do
      ! b2 = hess.b1'
      call DGEMV('N',3*natoms,3*natoms,1d0,hess,3*natoms,b1,1,0d0,b2,1)
      ! cgeom' = cgeom - H^-1.g
@@ -176,11 +319,40 @@ subroutine findmin(natoms,nstate,cgeom,isurf,maxiter,shift,Etol,Stol)
      if(nrmG<Etol.and.nrmD<Stol)then
        print *,"Optimization converged"
        print "(A,10F20.4)","Final energy of all states : ",e*au2cm1
+       converge_test=1
        return
      end if
   end do 
 1000 format("Iteration ",I4,": E=",F20.4,", |Grd|=",E12.5,", |Disp|=",E12.5)
+1001 format("Modes Removed: ",I4,F14.8)
 end subroutine findmin
+!==================================================================================
+!>analysegeom2
+! This subroutine prints the last geometry out to the file new.geom
+!----------------------------------------------------------------------------------
+subroutine analysegeom2(natoms,geom,aname,anum,masses,gflname)
+
+  implicit none
+  integer, intent(in)          ::  natoms
+  character*3,intent(in)       ::  aname(natoms)
+  character(len=300),intent(IN)      ::  gflname
+  double precision,intent(in)  ::  anum(natoms),masses(natoms)
+  double precision,intent(in)  ::  geom(3,natoms)
+  double precision, parameter  ::  bohr2ang=0.529177249d0
+  integer   ::  i, ios
+  
+  ! Open new file
+  open(unit=9,file=gflname,status="unknown",position="rewind",iostat=ios)
+  if (ios .ne. 0 ) then ! If file cannot be opened
+      print "(1x,A)", "Could not open geom file. (analysegeom2)"
+  end if
+  do i=1,natoms
+     write(unit=9, fmt="(x,a3,1x,f4.1,3F14.8,F14.8)") aname(i),anum(i),geom(:,i),masses(i)
+  end do
+  close(unit=9)
+  return
+end subroutine analysegeom2
+!===================================================================================
 end module opttools 
 
 ! main program
@@ -196,8 +368,33 @@ program findcp
   double precision,allocatable  :: cgeom(:)
   logical,allocatable           :: skip(:)
   double precision,external     :: dnrm2
-  character*300                 ::  geomfile,str
-
+  character*300                 ::  geomfile,str,inputfile
+  double precision,allocatable  :: dchess(:)
+  integer                       :: un_infile
+  integer                       :: converge_test
+  
+  integer               :: niter, printlvl
+  double precision      :: egrad_tol, shift, disp_tol, grad_scale, hess_disp, maxdisp
+  character*1           :: sadd_search
+  logical               :: check_inputfl, molden
+  character*300         :: new_geomfl, old_geomfl
+! Namelist input for inputfile
+  namelist /cpsearch/   niter, egrad_tol, shift, disp_tol, grad_scale, hess_disp, &
+      maxdisp, sadd_search, printlvl, molden
+! If not read in, here are the default values:
+  niter=100                         ! Max iterations
+  egrad_tol=1d-9                    ! Energy gradient tolerance for convergence
+  shift=1d-5                        ! Value of shift
+  disp_tol=1d-5                     ! Step size tolerance for convergence
+  un_infile=40                      ! Unit number of input file
+  grad_scale=1.0                    ! Scaling of gradient
+  hess_disp=1d-5                    ! Displacement for hessian calculation
+  maxdisp =1d-1                     ! Size of maximum displacement
+  sadd_search='N'                   ! Saddle point specific searching not implemented yet
+  old_geomfl="old.geom"             ! Old geometry file
+  new_geomfl="new.geom"             ! New geometry file
+  printlvl=0                        ! Print level
+  molden=.false.                    ! Generate molden output
 
   print *," ***************************************** "
   print *," *    findcp.x                           * "
@@ -218,6 +415,8 @@ program findcp
   allocate(w(3*natm))
   allocate(cgeom(3*natm))
   allocate(skip(natm))
+  allocate(dchess(3*natm))    !Dimension of diagonal correction to hessian
+  dchess=0d0
   skip = .false.
 
 ! process arguments
@@ -246,23 +445,46 @@ program findcp
     end if
   end if
 
+! Reading namelist input
+  call get_command_argument(number=3,value=inputfile,status=ios)
+  if(ios/=0)then      ! If no filename is provided, use default
+    print *, "Cannot find filename from command line options.  Using default."
+    inputfile="findcp.in"
+  endif
+! Open input file
+  inquire(file=inputfile,exist=check_inputfl)
+  if (check_inputfl) then
+      open(unit=un_infile,file=inputfile,iostat=ios)
+            read(unit=un_infile,nml=cpsearch)
+      close(unit=un_infile)
+  else
+        print *, "No input file found. Continuing with default values."
+  end if
+
   print *,"Reading input from input file "//trim(geomfile)
   call readColGeom(geomfile,1,natm,aname,anum,cgeom,masses)
 
   print "(/,A)","-------------- Initial Geometry ------------"
-  call analysegeom(natm,cgeom,aname,anum,masses,1.8d0,.true.)
+  call analysegeom(natm,cgeom,aname,anum,masses,2d0,.true.)
+  print "(/,A)"," Printing original geometry "
+  call analysegeom2(natm,cgeom,aname,anum,masses,old_geomfl)
   print "(/,A)","----------- Geometry Optimizations ---------"
-  call findmin(natm,nst,cgeom,isurf,100,1d-3,1d-8 ,1d-7)
+  converge_test=0
+  call findmin(natm,nst,cgeom,isurf,niter,shift,egrad_tol ,disp_tol,grad_scale,hess_disp,&
+    maxdisp, masses, sadd_search, converge_test)
   print "(/,A)","--------------- Final Geometry -------------"
-  call analysegeom(natm,cgeom,aname,anum,masses,1.8d0,.true.)
+  call analysegeom(natm,cgeom,aname,anum,masses,2d0,.true.)
   print "(/,A)","------------ Harmonic Frequencies ----------"
-  call calcHess(natm,cgeom,nst,isurf,1D-4,hess,.true.,skip)
+  call calcHess(natm,cgeom,nst,isurf,hess_disp,hess,.true.,skip)
   call writeHess(hess,3*natm)
-  call getFreq(natm,masses,hess,w)
+  call getFreq(natm,masses,hess,w,cgeom,aname,printlvl,molden)
   do i=1,3*natm
     print "(I5,F12.2)",i,w(i)
   end do
-
+ 
+  ! Print final geometry
+  call analysegeom2(natm,cgeom,aname,anum,masses,new_geomfl)
+  
 ! deallocate arrays
   deallocate(masses)
   deallocate(anum)
@@ -272,7 +494,7 @@ program findcp
   deallocate(cgeom)
   deallocate(skip)
 
-end
+end program findcp
 
 
 !------ write hessian file to disk, columbus format

--- a/utilities/testpoints/install.sh
+++ b/utilities/testpoints/install.sh
@@ -5,7 +5,7 @@ source ../../bin/setsgenvars.sh
 
 echo Compiling testpoints
 echo $SGENFC testpoints.f90 -o testpoints.x $SGENFLAG $SGENLIB
-$SGENFC testpoints.f90 -o testpoints.x $SGENFLAG $SGENLIB
+$SGENFC testpoints.f90 -o testpoints.x -g -fbacktrace $SGENFLAG $SGENLIB
 echo Copying executable to surfgen directory
 cp testpoints.x $SGENDIR
 echo Done 

--- a/utilities/testpoints/testpoints.f90
+++ b/utilities/testpoints/testpoints.f90
@@ -27,6 +27,8 @@ program testpoints
   double precision,external :: dnrm2
 
   logical :: printm ! print molden output
+  real*8,  dimension(:,:,:),allocatable :: hvec, svec, gvec !h/s/g vectors
+  integer, dimension(:),    allocatable :: mex
 
   print *,"-------------------------------------------------"
   print *,"Entering testpoints, a surfgen point testing utility"
@@ -37,7 +39,8 @@ program testpoints
 
   print *,""
   print *,"Checking for input file"
-  call read_input_file(printm)
+  allocate(mex(2))
+  call read_input_file(printm, mex)
   print *,""
   print *,"Initializing potential"
   call initPotential()
@@ -54,6 +57,9 @@ program testpoints
   allocate(h(nstates,nstates))
   allocate(cg(3*natoms,nstates,nstates))
   allocate(dcg(3*natoms,nstates,nstates))
+  allocate(hvec(3*natoms,nstates,nstates))
+  allocate(svec(3*natoms,nstates,nstates))
+  allocate(gvec(3*natoms,nstates,nstates))
 
   print *," Number of states:",nstates
   print *," Number of natoms:",natoms
@@ -94,6 +100,7 @@ program testpoints
     do j=2,nstates
       do k=1,j-1
         dvec=cg(:,j,j)-cg(:,k,k)
+        gvec(:,j,k)=dvec/2
         norms(k)=dnrm2(3*natoms,dvec,1)/2
       end do
       print "(I6,30E17.7)",j,norms(1:j-1)
@@ -104,6 +111,7 @@ program testpoints
     do j=2,nstates
       do k=1,j-1
         dvec=cg(:,j,k)*(e(j)-e(k))
+        hvec(:,j,k)=dvec
         norms(k)=dnrm2(3*natoms,dvec,1)
       end do
       print "(I6,30E17.7)",j,norms(1:j-1)
@@ -114,6 +122,7 @@ program testpoints
     do j=2,nstates
       do k=1,j-1
         dvec=cg(:,j,j)+cg(:,k,k)
+        svec(:,j,k)=dvec/2
         norms(k)=dnrm2(3*natoms,dvec,1)/2
       end do
       print "(I6,30E17.7)",j,norms(1:j-1)
@@ -134,6 +143,14 @@ program testpoints
          print "(3F18.10)",dcg(:,j,k)
       end do!k
     end do!j
+    if (printm .and. i .eq. npts .and. mex(1) .ne. 0) then
+            call print_molden_output(gvec, hvec, svec, nstates, &
+                natoms, atoms, cgeoms(:,i), mex)    
+            call rot_g_h_vectors(gvec(:,mex(2),mex(1)),hvec(:,mex(2),mex(1)),&
+                natoms) 
+            call express_s_in_ghplane(gvec(:,mex(2),mex(1)), &
+                hvec(:,mex(2),mex(1)), svec(:,mex(2),mex(1)), natoms)
+    end if
   end do!i
 
   ! get neighboring point index
@@ -141,35 +158,179 @@ program testpoints
   if(ptid/=0) print *,"Index of Closest Data Point : ", ptid
 
 contains
+  ! rot_g_h_vectors: rotate g and h vectors
+  subroutine rot_g_h_vectors(g, h, na)
+          implicit none
+          integer,intent(in) :: na
+          real*8, dimension(3*na), intent(inout) :: g, h
+          real*8, dimension(3*na) :: tmp1, tmp2
+          real*8 :: gh, hh, gg, atin, theta
+          real*8, external :: ddot
+
+          gh = ddot(na*3,g,1,h,1)
+          if (gh .lt. 1d-8) return
+          hh = ddot(na*3,h,1,h,1)
+          gg = ddot(na*3,g,1,g,1)
+          atin = (2 * gh) / (hh - gg)
+          theta= datan(atin) / 4.0
+
+          tmp1 = g
+          tmp2 = h
+          print "(A,f13.5)"," g.h = ", gh
+          print "(A,f8.3)"," Rotating by ", theta
+          g = dcos(2 * theta) * tmp1 - dsin(2 * theta) * tmp2
+          h = dsin(2 * theta) * tmp1 + dcos(2 * theta) * tmp2
+          gh = ddot(na*3,g,1,h,1)
+          print "(A,f13.5)"," g.h = ", gh
+          
+          return
+  end subroutine rot_g_h_vectors
+
+  ! express_s_in_ghplane: gives components of s in g/h plane.
+  subroutine express_s_in_ghplane(g, h, s, na)
+          implicit none
+          integer, intent(in) :: na
+          real*8, dimension(3*na), intent(in) :: g, h, s
+          real*8, dimension(3*na) :: gx, hy
+          real*8, external :: ddot
+          real*8, dimension(2) :: sxy
+          
+          gx = g / dsqrt(ddot(3*na,g,1,g,1))
+          hy = h / dsqrt(ddot(3*na,h,1,h,1))
+
+          sxy(1) = ddot(3*na,s,1,gx,1)
+          sxy(2) = ddot(3*na,s,1,hy,1)
+          
+          print "('||s|| = ',f8.3)", dnrm2(3*na,s,1)
+          print "('S vector in g-h plane:')"
+          print "('S(x,y) = (',f8.3,',',f8.3,')')", sxy(1), sxy(2)
+        
+          return
+  end subroutine express_s_in_ghplane
+
   ! read_input_file: reads input file for testpoints.x
-  subroutine read_input_file(printm)
+  subroutine read_input_file(printm, mex)
           implicit none
           logical, intent(out) :: printm
+          integer, dimension(2), intent(inout) :: mex
 
           character(25) :: flname = 'testpoints.in'
           integer       :: flunit = 21, ios
           integer, parameter :: fl_not_found = 29
 
-          namelist /testoutput/ printm
+          namelist /testoutput/ printm, mex
           printm = .false.
+          mex(1) = 0
+          mex(2) = 0
 
           ! Open input file. If file is not found, set printm = .false.
           ! and return. Else, read the file.
-          open(file = flname, unit = flunit, status = 'unknown', &
+          open(file = flname, unit = flunit, status = 'old', &
                   action = 'read', iostat = ios)
-          if (ios .eq. fl_not_found) then
-                  print *, "No input file found."
-                  return
-          else if (ios .eq. 0) then
+          if (ios .eq. 0) then
                   read(unit = flunit, nml = testoutput)
                   return
           else
-                  print "(a,i5,a)", "**Error ", ios, &
+                  print "(a,i5,a)", "  **Error ", ios, &
                           " occurred opening input file!**"
                   return
           end if
           return
   end subroutine read_input_file
 
-        
+  ! print_molden_output: print g/h/s vectors in molden format
+  subroutine print_molden_output(gv, hv, sv, ns, na, a, g, mex)
+          implicit none
+          integer, intent(in) :: ns, na
+          integer, dimension(2),          intent(in) :: mex
+          character(3), dimension(na),    intent(in) :: a
+          real*8,  dimension(3*na,ns,ns), intent(in) :: gv, hv, sv
+          real*8,  dimension(3*na),       intent(in) :: g
+          real*8,  dimension(:),         allocatable :: fq
+          character(25) :: flnm = 'vectors.molden'
+          integer       :: flun = 22, ios, i, j, nfq
+          
+          ! Allocate dummy frequencies. There will be n(n+1)/2, were 
+          ! n = states. Open file. Print vectors in order: g, h, s. 
+          !Lower triangle is printed.
+          
+          nfq = 3 * ns * (ns + 1) / 2
+          allocate(fq(nfq))
+          fq = 1d0
+
+          open(file = flnm, unit = flun, status = 'unknown', action = 'write',&
+                  iostat = ios)
+          if (ios .ne. 0) then
+                  print *, "**Error ", ios, " occurred opening vectors.molden!"
+                  return
+          end if        
+          write(flun,"(1x,'[Molden Format]')")
+
+          call print_molden_freq(flun, fq, 3)
+          call print_molden_geom(flun, g, a, na)
+          call print_molden_vecs(flun, gv, hv, sv, ns, na, nfq, mex)
+
+          close(flun)
+          return
+  end subroutine print_molden_output
+
+  ! print_molden_vecs: print vectors in molden format. Expects g/h/s
+  subroutine print_molden_vecs(u, gv, hv, sv, ns, na, nfq, mex)
+          implicit none
+          integer, intent(in) :: nfq, na, ns, u
+          integer, dimension(2), intent(in) :: mex
+          real*8,  dimension(3*na,ns,ns), intent(in) :: gv, hv, sv
+          real*8 :: ngv, nhv, nsv
+          integer :: i, j, p
+          
+          j = mex(1)
+          i = mex(2)
+          ngv = dnrm2(3*na,gv(:,i,j),1)
+          nhv = dnrm2(3*na,hv(:,i,j),1)
+          nsv = dnrm2(3*na,sv(:,i,j),1)
+
+          write(u,"(1x,'[FR-NORM-COORD]')")
+          p = 1
+          write(u,"(1x,'vibration',i24)") p
+          write(u,"(3f12.5)") gv(:,i,j)/ngv
+          p = 2
+          write(u,"(1x,'vibration',i24)") p
+          write(u,"(3f12.5)") hv(:,i,j)/nhv
+          p = 3
+          write(u,"(1x,'vibration',i24)") p
+          write(u,"(3f12.5)") sv(:,i,j)/nsv
+          return
+  end subroutine print_molden_vecs
+
+
+  ! print_molden_geom: print geometry in molden format, file is open.
+  subroutine print_molden_geom(u, g, a, na)
+          implicit none
+          integer, intent(in) :: u, na
+          character(3), dimension(na),intent(in) :: a
+          real*8,  dimension(3 * na), intent(in) :: g
+          integer :: i
+
+          write(u,"(1x,'[FR-COORD]')")
+          do i = 1, na
+                write(u,"(1x,a3,3f13.6)") a(i), g((i-1)*3+1), g((i-1)*3+2),&
+                        g((i-1)*3+3)
+          end do
+          return
+  end subroutine print_molden_geom
+
+  ! print_molden_freq: print frequencies to molden file, file is opened.
+  subroutine print_molden_freq(u, f, nf)
+          implicit none
+          integer, intent(in) :: u, nf
+          real*8,  dimension(nf), intent(in) :: f
+          integer :: i
+
+          write(u,"(1x,'[FREQ]')")
+          do i = 1, nf
+                write(u,"(f10.2)") f(i)
+          end do
+
+          return
+  end subroutine print_molden_freq
 end program testpoints

--- a/utilities/testpoints/testpoints.f90
+++ b/utilities/testpoints/testpoints.f90
@@ -7,6 +7,11 @@
 !
 ! For details see README file.
 !
+!-- Change Log --
+! 12-05-2015 - CLM - Added input file routine.
+!                    Added printing of s vector.
+!                    Added molden output of g/h/s vectors.
+!----------------
 !This program uses surfgen evaluation library for construction and evaluation of
 !Hd, as well as geometry input. 
 program testpoints
@@ -20,6 +25,9 @@ program testpoints
   double precision,dimension(:,:),allocatable  :: cgeoms,h
   double precision,dimension(:,:,:),allocatable:: cg,dcg
   double precision,external :: dnrm2
+
+  logical :: printm ! print molden output
+
   print *,"-------------------------------------------------"
   print *,"Entering testpoints, a surfgen point testing utility"
   print *,""
@@ -27,6 +35,9 @@ program testpoints
   print *,"  2013 Yarkony group, Johns Hopkins University"
   print *,"-------------------------------------------------"
 
+  print *,""
+  print *,"Checking for input file"
+  call read_input_file(printm)
   print *,""
   print *,"Initializing potential"
   call initPotential()
@@ -98,6 +109,16 @@ program testpoints
       print "(I6,30E17.7)",j,norms(1:j-1)
     end do
     print *,""
+    print *,"Norms of s vectors"
+    print "(8x,30I17)",(j,j=1,nstates-1)
+    do j=2,nstates
+      do k=1,j-1
+        dvec=cg(:,j,j)+cg(:,k,k)
+        norms(k)=dnrm2(3*natoms,dvec,1)/2
+      end do
+      print "(I6,30E17.7)",j,norms(1:j-1)
+    end do
+    print *,""
     print *,"Cartesian Gradients and Couplings in Adiabatic Representation"
     do j=1,nstates
       do k=1,j
@@ -118,4 +139,37 @@ program testpoints
   ! get neighboring point index
   call getNeighbor(ptid)
   if(ptid/=0) print *,"Index of Closest Data Point : ", ptid
+
+contains
+  ! read_input_file: reads input file for testpoints.x
+  subroutine read_input_file(printm)
+          implicit none
+          logical, intent(out) :: printm
+
+          character(25) :: flname = 'testpoints.in'
+          integer       :: flunit = 21, ios
+          integer, parameter :: fl_not_found = 29
+
+          namelist /testoutput/ printm
+          printm = .false.
+
+          ! Open input file. If file is not found, set printm = .false.
+          ! and return. Else, read the file.
+          open(file = flname, unit = flunit, status = 'unknown', &
+                  action = 'read', iostat = ios)
+          if (ios .eq. fl_not_found) then
+                  print *, "No input file found."
+                  return
+          else if (ios .eq. 0) then
+                  read(unit = flunit, nml = testoutput)
+                  return
+          else
+                  print "(a,i5,a)", "**Error ", ios, &
+                          " occurred opening input file!**"
+                  return
+          end if
+          return
+  end subroutine read_input_file
+
+        
 end program testpoints


### PR DESCRIPTION
…BRARY_PATH causes the make to build the executable penmp. A simple IF clause when setting  should fix this.